### PR TITLE
frontend: Use eth_requestAccounts instead of eth_accounts

### DIFF
--- a/frontend/src/stores/ethereum.ts
+++ b/frontend/src/stores/ethereum.ts
@@ -124,7 +124,7 @@ export const useEthereumStore = defineStore('ethereum', () => {
     const eth = await getEthereumProvider();
 
     const accounts: string[] = (await (eth.request?.({
-      method: 'eth_accounts',
+      method: 'eth_requestAccounts',
     }) || Promise.resolve([]))) as string[];
 
     if (!accounts || accounts?.length <= 0) {


### PR DESCRIPTION
Fixes #14 

When visiting a dApp for the first time, calling `eth_accounts` is forbidden. The user must first approve the dApp—the dApp needs to call `eth_requestAccounts` first and, if approved, then it may also use `eth_accounts`. This PR simply replaces `eth_accounts` with `eth_requestAccounts` since the behavior of the latter is the same as `eth_accounts` anyway once approved.