### PR TITLE
deps: Bumps sapphire-hardhat to ^2.22.3

### DIFF
--- a/.github/workflows/ci-playwright.yaml
+++ b/.github/workflows/ci-playwright.yaml
@@ -28,9 +28,9 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -3,10 +3,10 @@ name: ci-test
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   test-backend:
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 20
 
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
@@ -61,6 +61,8 @@ jobs:
         ports:
           - 8545:8545
           - 8546:8546
+        env:
+          OASIS_DOCKER_START_EXPLORER: no
         options: >-
           --rm
           --health-cmd="test -f /CONTAINER_READY"
@@ -70,15 +72,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 10
           run_install: false
 
       - name: Get pnpm store directory
@@ -105,7 +107,7 @@ jobs:
 
       - name: Test backend
         working-directory: backend
-        run: pnpm test -- --network sapphire-localnet
+        run: pnpm test --network sapphire-localnet
 
   test-frontend:
     runs-on: ubuntu-latest
@@ -114,15 +116,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
 
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 10
           run_install: false
 
       - name: Get pnpm store directory

--- a/backend/hardhat.config.ts
+++ b/backend/hardhat.config.ts
@@ -151,7 +151,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: '0.8.16',
+    version: '0.8.24',
     settings: {
       optimizer: {
         enabled: true,
@@ -184,7 +184,7 @@ const config: HardhatUserConfig = {
   etherscan: {
     enabled: false,
     apiKey: {},
-    customChains: []
+    customChains: [],
   },
 }
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,8 +7,8 @@
   "module": "./lib/esm/src/index.js",
   "types": "./lib/cjs/src/index.d.ts",
   "engines": {
-    "node": ">=18",
-    "pnpm": ">=8"
+    "node": ">=24",
+    "pnpm": ">=10"
   },
   "files": [
     "contracts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,7 +45,7 @@
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-verify": "^2.1.3",
     "@oasisprotocol/sapphire-contracts": "^0.2.12",
-    "@oasisprotocol/sapphire-hardhat": "^2.22.2",
+    "@oasisprotocol/sapphire-hardhat": "^2.22.3",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",
     "@types/chai": "^4.3.4",

--- a/backend/test/MessageBox.ts
+++ b/backend/test/MessageBox.ts
@@ -23,18 +23,20 @@ describe('MessageBox', function () {
   }
 
   it('Should set message authenticated', async function () {
-    // Skip this test on non-sapphire chains.
-    // On-chain encryption and/or signing required for SIWE.
-    if ((await ethers.provider.getNetwork()).chainId == 1337n) {
+    const { messageBox } = await deployMessageBox()
+
+    const tx = await messageBox.setMessage('hello world')
+    await tx.wait()
+
+    // Check, if author is correctly set.
+    expect(await messageBox.author()).to.equal(await(await ethers.provider.getSigner(0)).getAddress())
+
+    // Skip this test on non-sapphire chains because SIWE requires on-chain encryption and signing.
+    const chainId = (await ethers.provider.getNetwork()).chainId
+    if (chainId < 0x5afd || chainId > 0x5aff) {
       this.skip()
     }
 
-    const { messageBox } = await deployMessageBox()
-
-    await messageBox.setMessage('hello world')
-
-    // Check, if author is correctly set.
-    expect(await messageBox.author()).to.equal(await (await ethers.provider.getSigner(0)).getAddress())
     // Author should be able to read a message.
     const accounts = config.networks.hardhat.accounts
     const account = ethers.HDNodeWallet.fromMnemonic(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.14
       '@oasisprotocol/sapphire-hardhat':
-        specifier: ^2.22.2
-        version: 2.22.2(hardhat@2.24.1(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@18.19.105)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))
+        specifier: ^2.22.3
+        version: 2.22.3(hardhat@2.24.1(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@18.19.105)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))
       '@typechain/ethers-v6':
         specifier: ^0.5.1
         version: 0.5.1(ethers@6.14.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@4.9.5))(typescript@4.9.5)
@@ -849,13 +849,10 @@ packages:
   '@oasisprotocol/sapphire-contracts@0.2.14':
     resolution: {integrity: sha512-FYdJnHsnIBBME1Ggxc3pC1+NBa9HCaI/x4pDxSF2yBYbWvcFsd9M5+TJqP1BlZq6Z4D08v1+ahIcTzKF4YaGiw==}
 
-  '@oasisprotocol/sapphire-hardhat@2.22.2':
-    resolution: {integrity: sha512-43YYfsySrK/arbkurMd/AVOHpGwsZVvOrvQIS+TV8b56T0izLJuwe99Vou8U9GGiShBwFRuKl+J7pQWwvGWzPg==}
+  '@oasisprotocol/sapphire-hardhat@2.22.3':
+    resolution: {integrity: sha512-9GqmHx9XC2mMSuejFjoS6PnRH2zPfWmbA9N/LBBd0uGkzVxVkMquqqhz5WDq0qpzJqoKHVn5PhM5gG8We3DWWQ==}
     peerDependencies:
       hardhat: 2.x
-
-  '@oasisprotocol/sapphire-paratime@2.2.0':
-    resolution: {integrity: sha512-P8feNe2ecUgyL118b35BlkCmvfx4b3/7vKupdQw2YBotbqeOV82LunwHkgChuTf5BFjosDB+ad2wSqcuG4pHDA==}
 
   '@oasisprotocol/sapphire-paratime@2.3.0':
     resolution: {integrity: sha512-TooQ+eGxz8kQJ4PavqkXxvjbRJw8V4TB/Nu5ptaMyclFFr+tCWXEpx01gpoRsUEEc9IRcEm4IfnBUqFnBcbt7w==}
@@ -5572,23 +5569,16 @@ snapshots:
     dependencies:
       '@openzeppelin/contracts': 5.3.0
 
-  '@oasisprotocol/sapphire-hardhat@2.22.2(hardhat@2.24.1(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@18.19.105)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))':
+  '@oasisprotocol/sapphire-hardhat@2.22.3(hardhat@2.24.1(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@18.19.105)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10))':
     dependencies:
-      '@oasisprotocol/sapphire-paratime': 2.2.0
+      '@oasisprotocol/sapphire-paratime': 2.3.0
       hardhat: 2.24.1(bufferutil@4.0.9)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@18.19.105)(typescript@4.9.5))(typescript@4.9.5)(utf-8-validate@5.0.10)
-
-  '@oasisprotocol/sapphire-paratime@2.2.0':
-    dependencies:
-      '@noble/hashes': 1.3.2
-      '@oasisprotocol/deoxysii': 0.0.6
-      cborg: 1.10.2
 
   '@oasisprotocol/sapphire-paratime@2.3.0':
     dependencies:
       '@noble/hashes': 1.3.2
       '@oasisprotocol/deoxysii': 0.0.6
       cborg: 1.10.2
-    optional: true
 
   '@oasisprotocol/sapphire-viem-v2@2.1.0(@oasisprotocol/sapphire-paratime@2.3.0)(@wagmi/core@2.17.2(@tanstack/query-core@5.45.0)(@types/react@18.3.23)(react@18.3.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.30.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(typescript@5.8.3)(viem@2.30.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:


### PR DESCRIPTION
Also bumps solc to 0.8.24 and tests what it can be tested with hardhat tests before skipping.

Related to the new evm-1.1 tests.